### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for LinkedIn: Python bot library (`P6LIBot`), CLI helpers, and
+MCP server (`linkedin-mcp-server`) for AI-driven LinkedIn profile, feed,
+and messaging interactions.
 
 ## Contributing
 
@@ -38,8 +40,9 @@ TODO: Add a short summary of this module.
 - `p6df::modules::linkedin::deps()`
 - `p6df::modules::linkedin::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module
+    - dir
+- `p6df::modules::linkedin::mcp()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -29,3 +29,17 @@ p6df::modules::linkedin::init() {
 
   p6_python_path_if "$dir/lib"
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::linkedin::mcp()
+#
+#>
+######################################################################
+p6df::modules::linkedin::mcp() {
+
+  p6_js_npm_global_install "linkedin-mcp-server"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `linkedin-mcp-server` for AI-driven LinkedIn interactions (profile, feed, messaging) via MCP

## Test plan

- [ ] `p6df mcp` installs `linkedin-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)