### PR TITLE
refactor(init): remove stub profile::mod and fix env::init blank line

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -21,9 +21,9 @@ p6df::modules::linkedin::deps() {
 #>
 ######################################################################
 p6df::modules::linkedin::env::init() {
-
   local _module="$1"
   local _dir="$2"
+
   p6_python_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-linkedin/lib"
 
   p6_return_void
@@ -44,20 +44,4 @@ p6df::modules::linkedin::mcp() {
   p6df::modules::openai::mcp::server::add "linkedin" "npx" "-y" "linkedin-mcp-server"
 
   p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: words linkedin $LINKEDIN_API_KEY = p6df::modules::linkedin::profile::mod()
-#
-#  Returns:
-#	words - linkedin $LINKEDIN_API_KEY
-#
-#  Environment:	 LINKEDIN_API_KEY
-#>
-######################################################################
-p6df::modules::linkedin::profile::mod() {
-
-  p6_return_words 'linkedin' "$"
 }


### PR DESCRIPTION
## What
Remove the stub `p6df::modules::linkedin::profile::mod()` function and fix blank line placement in `env::init`.

## Why
The stub function returned a malformed value (`"$"`) with no real implementation. Removing it prevents accidental usage of broken code. The blank line fix improves code style consistency.

## Test plan
- Reviewed diff confirms only the stub function block is removed and blank line is repositioned
- No callers of the removed function exist in the codebase

## Dependencies
None